### PR TITLE
V2.2.0

### DIFF
--- a/02_release.md
+++ b/02_release.md
@@ -1,11 +1,6 @@
-- update changelog
-- push all changes in release branch
+- execute 03_release_helper.py
 - Raise PR to merge version branch to main
     - merge PR
-- build apk
-    - flutter clean
-    - flutter pub get
-    - flutter build apk --release
 - Draft a new release in github
     - https://github.com/JD1411GH/nitya_seva/releases/new
     - apply release tag to main
@@ -13,7 +8,6 @@
     - upload apk from `build\app\outputs\flutter-apk\app-release.apk`
     - publish release. mark as pre-release if all changes are not tested.
 - release in play store for internal testing
-    - create app bundle `flutter build appbundle --release`
     - Create new release
     - upload the app bundle from `build\app\outputs\bundle\release\app-release.aab`
 

--- a/03_release_helper.py
+++ b/03_release_helper.py
@@ -1,0 +1,59 @@
+import git
+import subprocess
+import sys
+
+def main():
+    repo = git.Repo('.')
+    logs = repo.git.log('--pretty=%B')
+
+    print("generate the changelog from git log")
+    log_messages = logs.split('\n\n')
+    filtered_log_messages = []
+    for i, log_message in enumerate(log_messages):
+        first_line = log_message.split('\n')[0]
+        word_count = len(first_line.split())
+        if first_line.startswith("Merge pull request"):
+            break
+        if word_count <= 8:
+            filtered_log_messages.append(log_message)
+    log_messages = filtered_log_messages
+
+    print("get the version number")
+    branch_name = repo.active_branch.name
+    version_number = branch_name.lstrip('v')
+
+    print("write changelog")
+    with open('changelog.md', 'r') as file:
+        existing_contents = file.read()
+    with open('changelog.md', 'w') as file:
+        file.write(f'# {version_number}\n')
+        for log_message in log_messages:
+            file.write(f'- {log_message}\n')
+        file.write('\n')  
+        file.write(existing_contents)
+
+    print("run the commands to build the release APK and AAB")
+    commands = [
+        "flutter clean",
+        "flutter pub get",
+        "flutter build apk --release",
+        "flutter build appbundle --release"
+    ]
+    try:
+        for command in commands:
+            subprocess.run(command, shell=True, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"An error occurred while executing: {e.cmd}")
+        sys.exit(1)
+
+    print("commit all changes and push to git")
+    if repo.is_dirty(untracked_files=True):
+        repo.git.add(A=True)
+        repo.index.commit(f'release {version_number}')
+        origin = repo.remote(name='origin')
+        origin.push()
+    else:
+        print("No changes to commit")
+
+if __name__ == '__main__':
+    main()

--- a/03_release_helper.py
+++ b/03_release_helper.py
@@ -14,7 +14,7 @@ def main():
         word_count = len(first_line.split())
         if first_line.startswith("Merge pull request"):
             break
-        if word_count <= 8:
+        if word_count <= 8 and not first_line.startswith("Refactor"):
             filtered_log_messages.append(log_message)
     log_messages = filtered_log_messages
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,66 @@
+# 2.2.0
+- fix return
+- laddu return count in summary
+- serve keyboard is now numeric
+- slot balance is shown in serve tile
+- title in seva history made uniform with summary
+- delete serve
+- all fields are made mandatory in a dialog
+- return is editable
+- missing laddu packs
+- pie display only served tickets
+- prevent multiple refresh
+- edit serve
+- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
+- Related to #issue_number
+- new serve types added
+- log serve
+- other seva fb entry
+- Refactor variable names in laddu_calc.dart and avilability_bar.dart
+- rename ticketAmounts
+
+# 2.2.0
+- fix return
+- laddu return count in summary
+- serve keyboard is now numeric
+- slot balance is shown in serve tile
+- title in seva history made uniform with summary
+- delete serve
+- all fields are made mandatory in a dialog
+- return is editable
+- missing laddu packs
+- pie display only served tickets
+- prevent multiple refresh
+- edit serve
+- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
+- Related to #issue_number
+- new serve types added
+- log serve
+- other seva fb entry
+- Refactor variable names in laddu_calc.dart and avilability_bar.dart
+- rename ticketAmounts
+
+# 2.2.0
+- fix return
+- laddu return count in summary
+- serve keyboard is now numeric
+- slot balance is shown in serve tile
+- title in seva history made uniform with summary
+- delete serve
+- all fields are made mandatory in a dialog
+- return is editable
+- missing laddu packs
+- pie display only served tickets
+- prevent multiple refresh
+- edit serve
+- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
+- Related to #issue_number
+- new serve types added
+- log serve
+- other seva fb entry
+- Refactor variable names in laddu_calc.dart and avilability_bar.dart
+- rename ticketAmounts
+
 # 2.1.1
 - Laddu seva
     - disable edit serve

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # 2.2.0
+- release 2.2.0
 - fix return
 - laddu return count in summary
 - serve keyboard is now numeric
@@ -11,55 +12,12 @@
 - pie display only served tickets
 - prevent multiple refresh
 - edit serve
-- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
 - Related to #issue_number
 - new serve types added
 - log serve
 - other seva fb entry
-- Refactor variable names in laddu_calc.dart and avilability_bar.dart
 - rename ticketAmounts
 
-# 2.2.0
-- fix return
-- laddu return count in summary
-- serve keyboard is now numeric
-- slot balance is shown in serve tile
-- title in seva history made uniform with summary
-- delete serve
-- all fields are made mandatory in a dialog
-- return is editable
-- missing laddu packs
-- pie display only served tickets
-- prevent multiple refresh
-- edit serve
-- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
-- Related to #issue_number
-- new serve types added
-- log serve
-- other seva fb entry
-- Refactor variable names in laddu_calc.dart and avilability_bar.dart
-- rename ticketAmounts
-
-# 2.2.0
-- fix return
-- laddu return count in summary
-- serve keyboard is now numeric
-- slot balance is shown in serve tile
-- title in seva history made uniform with summary
-- delete serve
-- all fields are made mandatory in a dialog
-- return is editable
-- missing laddu packs
-- pie display only served tickets
-- prevent multiple refresh
-- edit serve
-- Refactor laddu_seva/avilability_bar.dart and laddu_seva/history_list.dart
-- Related to #issue_number
-- new serve types added
-- log serve
-- other seva fb entry
-- Refactor variable names in laddu_calc.dart and avilability_bar.dart
-- rename ticketAmounts
 
 # 2.1.1
 - Laddu seva

--- a/lib/const.dart
+++ b/lib/const.dart
@@ -31,6 +31,11 @@ class Const {
     {'amount': 2500, 'ladduPacks': 3},
   ];
 
+  List<Map<String, dynamic>> otherSevaTickets = [
+    {'name': "Special Puja", 'amount': 0, 'ladduPacks': 1},
+    {'name': "Festival", 'amount': 500, 'ladduPacks': 2},
+  ];
+
   // theme ticketColors
   final Color colorPrimary =
       ColorScheme.fromSeed(seedColor: const Color(0xFF3B4043)).primary;

--- a/lib/const.dart
+++ b/lib/const.dart
@@ -24,7 +24,7 @@ class Const {
   DateTime morningCutoff = DateTime(
       DateTime.now().year, DateTime.now().month, DateTime.now().day, 14, 0);
 
-  List<Map<String, int>> ticketAmounts = [
+  List<Map<String, int>> pushpanjaliTickets = [
     {'amount': 400, 'ladduPacks': 1},
     {'amount': 500, 'ladduPacks': 1},
     {'amount': 1000, 'ladduPacks': 2},

--- a/lib/const.dart
+++ b/lib/const.dart
@@ -32,8 +32,18 @@ class Const {
   ];
 
   List<Map<String, dynamic>> otherSevaTickets = [
-    {'name': "Special Puja", 'amount': 0, 'ladduPacks': 1},
-    {'name': "Festival", 'amount': 500, 'ladduPacks': 2},
+    {
+      'name': "Special Puja",
+      'amount': 0,
+      'ladduPacks': 1,
+      'color': Colors.pink[900]
+    },
+    {
+      'name': "Festival",
+      'amount': 500,
+      'ladduPacks': 2,
+      'color': Colors.indigo[900]
+    },
   ];
 
   // theme ticketColors

--- a/lib/fb.dart
+++ b/lib/fb.dart
@@ -814,15 +814,11 @@ class FB {
     final DatabaseReference dbRef = FirebaseDatabase.instance
         .ref('record_db${Const().dbVersion}/ladduSeva/$a/returned');
 
-    // set return status
-    DatabaseReference refRet = dbRef.child('count');
-    await refRet.set(lr.count);
-
-    refRet = dbRef.child('to');
-    await refRet.set(lr.to);
-
-    refRet = dbRef.child('timestamp');
-    await refRet.set(lr.timestamp.toIso8601String());
+    await dbRef.update({
+      'count': lr.count,
+      'to': lr.to,
+      'timestamp': lr.timestamp.toIso8601String(),
+    });
   }
 }
 

--- a/lib/fb.dart
+++ b/lib/fb.dart
@@ -684,16 +684,15 @@ class FB {
     return true;
   }
 
-  // TODO
-  Future<bool> deleteLadduDist(DateTime session, LadduServe dist) async {
+  Future<bool> deleteLadduServe(DateTime session, LadduServe serve) async {
     String a = session.toIso8601String().replaceAll(".", "^");
     final DatabaseReference dbRef = FirebaseDatabase.instance
         .ref('record_db${Const().dbVersion}/ladduSeva/$a');
 
-    // delete laddu stock
-    DateTime timestamp = dist.timestamp;
+    // delete laddu serve
+    DateTime timestamp = serve.timestamp;
     DatabaseReference ref = dbRef
-        .child('dists')
+        .child('serves')
         .child(timestamp.toIso8601String().replaceAll(".", "^"));
     try {
       DataSnapshot snapshot = await ref.get();

--- a/lib/fb.dart
+++ b/lib/fb.dart
@@ -636,20 +636,20 @@ class FB {
     await refRet.set(lr.to);
   }
 
-  Future<bool> editLadduDist(DateTime session, LadduServe dist) async {
-    String a = session.toIso8601String().replaceAll(".", "^");
+  Future<bool> editLadduServe(DateTime session, LadduServe serve) async {
+    String s = session.toIso8601String().replaceAll(".", "^");
     final DatabaseReference dbRef = FirebaseDatabase.instance
-        .ref('record_db${Const().dbVersion}/ladduSeva/$a');
+        .ref('record_db${Const().dbVersion}/ladduSeva/$s');
 
-    // Add a new laddu stock
-    DateTime timestamp = dist.timestamp;
+    // edit laddu stock
+    DateTime timestamp = serve.timestamp;
     DatabaseReference ref = dbRef
-        .child('dists')
+        .child('serves')
         .child(timestamp.toIso8601String().replaceAll(".", "^"));
     try {
       DataSnapshot snapshot = await ref.get();
       if (snapshot.exists) {
-        await ref.set(dist.toJson());
+        await ref.set(serve.toJson());
       } else {
         return false;
       }
@@ -684,6 +684,7 @@ class FB {
     return true;
   }
 
+  // TODO
   Future<bool> deleteLadduDist(DateTime session, LadduServe dist) async {
     String a = session.toIso8601String().replaceAll(".", "^");
     final DatabaseReference dbRef = FirebaseDatabase.instance

--- a/lib/fb.dart
+++ b/lib/fb.dart
@@ -809,14 +809,15 @@ class FB {
   }
 
   Future<void> returnLadduStock(DateTime session, LadduReturn lr) async {
-    String a = session.toIso8601String().replaceAll(".", "^");
+    String s = session.toIso8601String().replaceAll(".", "^");
     final DatabaseReference dbRef = FirebaseDatabase.instance
-        .ref('record_db${Const().dbVersion}/ladduSeva/$a/returned');
+        .ref('record_db${Const().dbVersion}/ladduSeva/$s/returned');
 
     await dbRef.update({
       'count': lr.count,
       'to': lr.to,
       'timestamp': lr.timestamp.toIso8601String(),
+      'user': lr.user,
     });
   }
 }

--- a/lib/laddu_seva/avilability_bar.dart
+++ b/lib/laddu_seva/avilability_bar.dart
@@ -43,7 +43,7 @@ class _AvailabilityBarState extends State<AvailabilityBar> {
 
       total_served = 0;
       for (LadduServe serve in serves) {
-        total_served += CalculateTotalLadduPacks(serve);
+        total_served += CalculateTotalLadduPacksServed(serve);
       }
     });
   }

--- a/lib/laddu_seva/avilability_bar.dart
+++ b/lib/laddu_seva/avilability_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
+import 'package:garuda/laddu_seva/utils.dart';
 import 'package:synchronized/synchronized.dart';
 
 class AvailabilityBar extends StatefulWidget {
@@ -42,7 +43,7 @@ class _AvailabilityBarState extends State<AvailabilityBar> {
 
       total_served = 0;
       for (LadduServe serve in serves) {
-        total_served += serve.totalPacks();
+        total_served += CalculateTotalLadduPacks(serve);
       }
     });
   }

--- a/lib/laddu_seva/avilability_bar.dart
+++ b/lib/laddu_seva/avilability_bar.dart
@@ -48,6 +48,12 @@ class _AvailabilityBarState extends State<AvailabilityBar> {
           });
         });
 
+        serve.packsOtherSeva.forEach((element) {
+          element.forEach((key, value) {
+            total_served += value;
+          });
+        });
+
         serve.packsMisc.forEach((element) {
           element.forEach((key, value) {
             total_served += value;

--- a/lib/laddu_seva/avilability_bar.dart
+++ b/lib/laddu_seva/avilability_bar.dart
@@ -48,7 +48,7 @@ class _AvailabilityBarState extends State<AvailabilityBar> {
           });
         });
 
-        serve.packsOthers.forEach((element) {
+        serve.packsMisc.forEach((element) {
           element.forEach((key, value) {
             total_served += value;
           });

--- a/lib/laddu_seva/avilability_bar.dart
+++ b/lib/laddu_seva/avilability_bar.dart
@@ -42,23 +42,7 @@ class _AvailabilityBarState extends State<AvailabilityBar> {
 
       total_served = 0;
       for (LadduServe serve in serves) {
-        serve.packsPushpanjali.forEach((element) {
-          element.forEach((key, value) {
-            total_served += value;
-          });
-        });
-
-        serve.packsOtherSeva.forEach((element) {
-          element.forEach((key, value) {
-            total_served += value;
-          });
-        });
-
-        serve.packsMisc.forEach((element) {
-          element.forEach((key, value) {
-            total_served += value;
-          });
-        });
+        total_served += serve.totalPacks();
       }
     });
   }

--- a/lib/laddu_seva/datatypes.dart
+++ b/lib/laddu_seva/datatypes.dart
@@ -35,6 +35,7 @@ class LadduServe {
   final DateTime timestamp;
   final String user;
   final List<Map<String, int>> packsPushpanjali;
+  final List<Map<String, int>> packsOtherSeva;
   final List<Map<String, int>> packsMisc;
   final String note;
   final String title;
@@ -44,6 +45,7 @@ class LadduServe {
     required this.user,
     required this.packsPushpanjali,
     required this.packsMisc,
+    required this.packsOtherSeva,
     required this.note,
     required this.title,
   });
@@ -56,6 +58,9 @@ class LadduServe {
           .map((item) => Map<String, int>.from(item))
           .toList(),
       packsMisc: (json['packsMisc'] as List)
+          .map((item) => Map<String, int>.from(item))
+          .toList(),
+      packsOtherSeva: (json['packsOtherSeva'] as List)
           .map((item) => Map<String, int>.from(item))
           .toList(),
       note: json['note'],
@@ -72,6 +77,10 @@ class LadduServe {
               item.map((key, value) => MapEntry(key.toString(), value)))
           .toList(),
       'packsMisc': packsMisc,
+      'packsOtherSeva': packsOtherSeva
+          .map((item) =>
+              item.map((key, value) => MapEntry(key.toString(), value)))
+          .toList(),
       'note': note,
       'title': title,
     };

--- a/lib/laddu_seva/datatypes.dart
+++ b/lib/laddu_seva/datatypes.dart
@@ -85,6 +85,29 @@ class LadduServe {
       'title': title,
     };
   }
+
+  int totalPacks() {
+    int total = 0;
+    packsPushpanjali.forEach((element) {
+      element.forEach((key, value) {
+        total += value;
+      });
+    });
+
+    packsOtherSeva.forEach((element) {
+      element.forEach((key, value) {
+        total += value;
+      });
+    });
+
+    packsMisc.forEach((element) {
+      element.forEach((key, value) {
+        total += value;
+      });
+    });
+
+    return total;
+  }
 }
 
 class LadduDistAccumulated {

--- a/lib/laddu_seva/datatypes.dart
+++ b/lib/laddu_seva/datatypes.dart
@@ -39,6 +39,7 @@ class LadduServe {
   final List<Map<String, int>> packsMisc;
   final String note;
   final String title;
+  final int balance; // New member
 
   LadduServe({
     required this.timestamp,
@@ -48,6 +49,7 @@ class LadduServe {
     required this.packsOtherSeva,
     required this.note,
     required this.title,
+    required this.balance, // Updated constructor
   });
 
   factory LadduServe.fromJson(Map<String, dynamic> json) {
@@ -65,6 +67,7 @@ class LadduServe {
           .toList(),
       note: json['note'],
       title: json['title'],
+      balance: json['balance'], // Updated fromJson
     );
   }
 
@@ -83,39 +86,7 @@ class LadduServe {
           .toList(),
       'note': note,
       'title': title,
-    };
-  }
-}
-
-class LadduDistAccumulated {
-  final String date;
-  int count;
-  List<String> users;
-  List<String> notes;
-
-  LadduDistAccumulated(
-      {required this.date,
-      required this.count,
-      required this.users,
-      required this.notes});
-
-  // Factory constructor to create an instance from a JSON map
-  factory LadduDistAccumulated.fromJson(Map<String, dynamic> json) {
-    return LadduDistAccumulated(
-      date: json['date'],
-      count: json['count'],
-      users: List<String>.from(json['users']),
-      notes: List<String>.from(json['notes']),
-    );
-  }
-
-  // Method to convert an instance to a JSON map
-  Map<String, dynamic> toJson() {
-    return {
-      'date': date,
-      'count': count,
-      'users': users,
-      'notes': notes,
+      'balance': balance, // Updated toJson
     };
   }
 }

--- a/lib/laddu_seva/datatypes.dart
+++ b/lib/laddu_seva/datatypes.dart
@@ -85,29 +85,6 @@ class LadduServe {
       'title': title,
     };
   }
-
-  int totalPacks() {
-    int total = 0;
-    packsPushpanjali.forEach((element) {
-      element.forEach((key, value) {
-        total += value;
-      });
-    });
-
-    packsOtherSeva.forEach((element) {
-      element.forEach((key, value) {
-        total += value;
-      });
-    });
-
-    packsMisc.forEach((element) {
-      element.forEach((key, value) {
-        total += value;
-      });
-    });
-
-    return total;
-  }
 }
 
 class LadduDistAccumulated {

--- a/lib/laddu_seva/datatypes.dart
+++ b/lib/laddu_seva/datatypes.dart
@@ -35,7 +35,7 @@ class LadduServe {
   final DateTime timestamp;
   final String user;
   final List<Map<String, int>> packsPushpanjali;
-  final List<Map<String, int>> packsOthers;
+  final List<Map<String, int>> packsMisc;
   final String note;
   final String title;
 
@@ -43,7 +43,7 @@ class LadduServe {
     required this.timestamp,
     required this.user,
     required this.packsPushpanjali,
-    required this.packsOthers,
+    required this.packsMisc,
     required this.note,
     required this.title,
   });
@@ -55,7 +55,7 @@ class LadduServe {
       packsPushpanjali: (json['packsPushpanjali'] as List)
           .map((item) => Map<String, int>.from(item))
           .toList(),
-      packsOthers: (json['packsOthers'] as List)
+      packsMisc: (json['packsMisc'] as List)
           .map((item) => Map<String, int>.from(item))
           .toList(),
       note: json['note'],
@@ -71,7 +71,7 @@ class LadduServe {
           .map((item) =>
               item.map((key, value) => MapEntry(key.toString(), value)))
           .toList(),
-      'packsOthers': packsOthers,
+      'packsMisc': packsMisc,
       'note': note,
       'title': title,
     };

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -79,7 +79,7 @@ class _HistoryListState extends State<HistoryList> {
             }
           });
 
-          serve.packsOthers.forEach((element) {
+          serve.packsMisc.forEach((element) {
             String key = element.keys.first;
             if (purposeSum.containsKey(key)) {
               purposeSum[key] = purposeSum[key]! + element.values.first;
@@ -153,7 +153,7 @@ class _HistoryListState extends State<HistoryList> {
       total += element.values.first;
     });
 
-    serve.packsOthers.forEach((element) {
+    serve.packsMisc.forEach((element) {
       total += element.values.first;
     });
 

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -57,7 +57,7 @@ class _HistoryListState extends State<HistoryList> {
         int totalServed = 0;
         Map<String, int> purposeSum = {};
         for (LadduServe serve in serves) {
-          totalServed += CalculateTotalLadduPacks(serve);
+          totalServed += CalculateTotalLadduPacksServed(serve);
 
           serve.packsPushpanjali.forEach((element) {
             String key = "Seva ${element.keys.first}";

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:garuda/const.dart';
 import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
+import 'package:garuda/laddu_seva/utils.dart';
 import 'package:intl/intl.dart';
 import 'package:synchronized/synchronized.dart';
 
@@ -51,9 +52,18 @@ class _HistoryListState extends State<HistoryList> {
           endSession = stocks.last.timestamp;
         }
 
-        String title = DateFormat("EEE, MMM dd").format(startSession);
-        if (startSession.day != endSession.day) {
-          title += DateFormat(" - EEE, MMM dd").format(endSession);
+        String sessionTitle = DateFormat("EEE, MMM dd").format(session);
+        LadduReturn lr = await FB().readLadduReturnStatus(session);
+        if (lr.count >= 0) {
+          String endSession = DateFormat("EEE, MMM dd").format(lr.timestamp);
+          if (sessionTitle != endSession) {
+            sessionTitle += " - $endSession";
+          }
+        } else {
+          DateTime now = DateTime.now();
+          if (session.day != now.day) {
+            sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
+          }
         }
 
         List<String> body = [];
@@ -67,7 +77,7 @@ class _HistoryListState extends State<HistoryList> {
         int totalServed = 0;
         Map<String, int> purposeSum = {};
         for (LadduServe serve in serves) {
-          totalServed += serve.totalPacks();
+          totalServed += CalculateTotalLadduPacks(serve);
 
           serve.packsPushpanjali.forEach((element) {
             String key = "Seva ${element.keys.first}";

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -68,7 +68,7 @@ class _HistoryListState extends State<HistoryList> {
         int totalServed = 0;
         Map<String, int> purposeSum = {};
         for (LadduServe serve in serves) {
-          totalServed += _calculateTotalLadduPacksServed(serve);
+          totalServed += serve.totalPacks();
 
           serve.packsPushpanjali.forEach((element) {
             String key = "Seva ${element.keys.first}";
@@ -106,6 +106,7 @@ class _HistoryListState extends State<HistoryList> {
             body.add("    $purpose = $count");
           }
         });
+        body.add("Total laddu packs served = $totalServed");
 
         LadduReturn lr = await FB().readLadduReturnStatus(session);
         if (lr.count >= 0) {
@@ -153,20 +154,6 @@ class _HistoryListState extends State<HistoryList> {
   Future<void> refresh(DateTime month) async {
     await _futureInit(month);
     setState(() {});
-  }
-
-  int _calculateTotalLadduPacksServed(LadduServe serve) {
-    int total = 0;
-
-    serve.packsPushpanjali.forEach((element) {
-      total += element.values.first;
-    });
-
-    serve.packsMisc.forEach((element) {
-      total += element.values.first;
-    });
-
-    return total;
   }
 
   @override

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -79,6 +79,15 @@ class _HistoryListState extends State<HistoryList> {
             }
           });
 
+          serve.packsOtherSeva.forEach((element) {
+            String key = "${element.keys.first}";
+            if (purposeSum.containsKey(key)) {
+              purposeSum[key] = purposeSum[key]! + element.values.first;
+            } else {
+              purposeSum[key] = element.values.first;
+            }
+          });
+
           serve.packsMisc.forEach((element) {
             String key = element.keys.first;
             if (purposeSum.containsKey(key)) {

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:garuda/const.dart';
 import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
-import 'package:garuda/laddu_seva/history_edit.dart';
 import 'package:intl/intl.dart';
 import 'package:synchronized/synchronized.dart';
 

--- a/lib/laddu_seva/history_list.dart
+++ b/lib/laddu_seva/history_list.dart
@@ -44,27 +44,7 @@ class _HistoryListState extends State<HistoryList> {
         List<LadduServe> serves = await FB().readLadduServes(session);
         serves.sort((a, b) => a.timestamp.compareTo(b.timestamp));
 
-        DateTime startSession = session;
-        DateTime endSession = session;
-
-        if (serves.isNotEmpty &&
-            stocks.last.timestamp.isAfter(serves.last.timestamp)) {
-          endSession = stocks.last.timestamp;
-        }
-
-        String sessionTitle = DateFormat("EEE, MMM dd").format(session);
-        LadduReturn lr = await FB().readLadduReturnStatus(session);
-        if (lr.count >= 0) {
-          String endSession = DateFormat("EEE, MMM dd").format(lr.timestamp);
-          if (sessionTitle != endSession) {
-            sessionTitle += " - $endSession";
-          }
-        } else {
-          DateTime now = DateTime.now();
-          if (session.day != now.day) {
-            sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
-          }
-        }
+        String title = await CalculateSessionTitle(session);
 
         List<String> body = [];
 

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -267,7 +267,7 @@ Future<void> returnStock(BuildContext context, {LadduReturn? lr}) async {
   // sum of all distributions
   int totalServe = 0;
   serves.forEach((serve) {
-    totalServe += CalculateTotalLadduPacks(serve);
+    totalServe += CalculateTotalLadduPacksServed(serve);
   });
 
   int remaining = totalStock - totalServe;
@@ -379,8 +379,6 @@ class _ReturnStockDialogState extends State<ReturnStockDialog> {
         ),
       ),
       actions: <Widget>[
-        // TODO delete button
-
         // cancel button
         ElevatedButton(
           onPressed: () {

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -232,7 +232,7 @@ int _calculateTotalLadduPacksServed(LadduServe serve) {
     total += element.values.first;
   });
 
-  serve.packsOthers.forEach((element) {
+  serve.packsMisc.forEach((element) {
     total += element.values.first;
   });
 

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:garuda/const.dart';
 import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
+import 'package:garuda/laddu_seva/utils.dart';
 import 'package:garuda/toaster.dart';
 
 String selectedPurpose = "Others";
@@ -266,7 +267,7 @@ Future<void> returnStock(BuildContext context, {LadduReturn? lr}) async {
   // sum of all distributions
   int totalServe = 0;
   serves.forEach((serve) {
-    totalServe += serve.totalPacks();
+    totalServe += CalculateTotalLadduPacks(serve);
   });
 
   int remaining = totalStock - totalServe;

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -88,6 +88,17 @@ class _AddEditStockDialogState extends State<AddEditStockDialog> {
         if (widget.edit)
           ElevatedButton(
             onPressed: () async {
+              DateTime session =
+                  widget.session ?? await FB().readLatestLadduSession();
+
+              // check if this is the only stock entry
+              List<LadduStock> stocks = await FB().readLadduStocks(session);
+              if (stocks.length == 1) {
+                Toaster().error("Cannot delete the only stock entry");
+                return;
+              }
+
+              // confirm delete
               bool? confirm = await showDialog<bool>(
                 context: context,
                 builder: (BuildContext context) {
@@ -117,8 +128,6 @@ class _AddEditStockDialogState extends State<AddEditStockDialog> {
                   isLoading = true;
                 });
 
-                DateTime session =
-                    widget.session ?? await FB().readLatestLadduSession();
                 await FB().deleteLadduStock(session, widget.stock!);
 
                 setState(() {

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -225,20 +225,6 @@ Future<void> addEditStock(BuildContext context,
   );
 }
 
-int _calculateTotalLadduPacksServed(LadduServe serve) {
-  int total = 0;
-
-  serve.packsPushpanjali.forEach((element) {
-    total += element.values.first;
-  });
-
-  serve.packsMisc.forEach((element) {
-    total += element.values.first;
-  });
-
-  return total;
-}
-
 Future<void> returnStock(BuildContext context) async {
   DateTime session = await FB().readLatestLadduSession();
 
@@ -265,7 +251,7 @@ Future<void> returnStock(BuildContext context) async {
   // sum of all distributions
   int totalServe = 0;
   serves.forEach((serve) {
-    totalServe += _calculateTotalLadduPacksServed(serve);
+    totalServe += serve.totalPacks();
   });
 
   int remaining = totalStock - totalServe;

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -428,10 +428,10 @@ class _ReturnStockDialogState extends State<ReturnStockDialog> {
 }
 
 Widget _getPurposeDropDown(BuildContext context, {String? defaultPurpose}) {
-  List<int?> ticketAmounts =
-      Const().ticketAmounts.map((e) => e['amount']).toList();
+  List<int?> pushpanjaliTickets =
+      Const().pushpanjaliTickets.map((e) => e['amount']).toList();
   List<String> Purposes =
-      ticketAmounts.map((e) => "Seva ${e.toString()}").toList();
+      pushpanjaliTickets.map((e) => "Seva ${e.toString()}").toList();
 
   Purposes.add("Others");
   Purposes.add("Missing");

--- a/lib/laddu_seva/laddu_calc.dart
+++ b/lib/laddu_seva/laddu_calc.dart
@@ -52,6 +52,12 @@ class _AddEditStockDialogState extends State<AddEditStockDialog> {
               controller: TextEditingController(
                 text: widget.edit ? widget.stock!.from : '',
               ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter a valid name';
+                }
+                return null;
+              },
             ),
 
             // text input for packs procured
@@ -305,6 +311,7 @@ class ReturnStockDialog extends StatefulWidget {
 
 class _ReturnStockDialogState extends State<ReturnStockDialog> {
   bool _isLoading = false;
+  final _formKey = GlobalKey<FormState>(); // required for form valudation
 
   @override
   void initState() {
@@ -321,44 +328,53 @@ class _ReturnStockDialogState extends State<ReturnStockDialog> {
     return AlertDialog(
       title: Text('Return laddu stock'),
       content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Align(
-              alignment: Alignment.centerLeft,
-              child: TextField(
-                controller: TextEditingController(
-                    text: widget.lr != null ? widget.lr!.to : ''),
-                decoration: InputDecoration(
-                  labelText: 'Returned to',
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextFormField(
+                  controller: TextEditingController(
+                      text: widget.lr != null ? widget.lr!.to : ''),
+                  decoration: InputDecoration(
+                    labelText: 'Returned to',
+                  ),
+                  onChanged: (value) {
+                    widget.returnedTo = value;
+                  },
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Please enter a name';
+                    }
+                    return null;
+                  },
                 ),
-                onChanged: (value) {
-                  widget.returnedTo = value;
-                },
               ),
-            ),
-            SizedBox(height: 8.0),
-            Align(
-              alignment: Alignment.centerLeft,
-              child: TextField(
-                controller: TextEditingController(
-                    text: widget.lr != null
-                        ? widget.lr!.count.toString()
-                        : widget.remaining.toString()),
-                decoration: InputDecoration(
-                  labelText: 'Packs returned',
+              SizedBox(height: 8.0),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextField(
+                  controller: TextEditingController(
+                      text: widget.lr != null
+                          ? widget.lr!.count.toString()
+                          : widget.remaining.toString()),
+                  decoration: InputDecoration(
+                    labelText: 'Packs returned',
+                  ),
+                  onChanged: (value) {
+                    if (value.isNotEmpty) widget.returnCount = int.parse(value);
+                  },
                 ),
-                onChanged: (value) {
-                  if (value.isNotEmpty) widget.returnCount = int.parse(value);
-                },
               ),
-            ),
-            if (_isLoading)
-              Center(
-                child: CircularProgressIndicator(),
-              ),
-          ],
+              if (_isLoading)
+                Center(
+                  child: CircularProgressIndicator(),
+                ),
+            ],
+          ),
         ),
       ),
       actions: <Widget>[
@@ -388,6 +404,11 @@ class _ReturnStockDialogState extends State<ReturnStockDialog> {
   }
 
   Future<void> _confirm() async {
+    // validate the form
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
     setState(() {
       _isLoading = true;
     });

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -182,8 +182,6 @@ class _LogState extends State<Log> {
                           serve: serve,
                         )),
               );
-              // addEditDist(context,
-              //     edit: true, serve: serve, session: widget.session);
             });
 
         // heading for laddu packs served

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -204,12 +204,12 @@ class _LogState extends State<Log> {
         }
 
         // other seva tickets
-        for (int i = 0; i < serve.packsPushpanjali.length; i++) {
-          if (serve.packsPushpanjali[i].values.first != 0) {
+        for (int i = 0; i < serve.packsOtherSeva.length; i++) {
+          if (serve.packsOtherSeva[i].values.first != 0) {
             (tile.subtitle as Column).children.add(Align(
                   alignment: Alignment.centerLeft,
                   child: Text(
-                    '    Seva ${serve.packsPushpanjali[i].keys.first}: ${serve.packsPushpanjali[i].values.first}',
+                    '    ${serve.packsOtherSeva[i].keys.first}: ${serve.packsOtherSeva[i].values.first}',
                   ),
                 ));
           }

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -84,7 +84,7 @@ class _LogState extends State<Log> {
       // add the logs for laddu serves
       List<LadduServe> serves = await FB().readLadduServes(session);
       for (LadduServe serve in serves) {
-        _logItems.add(ListTile(
+        ListTile tile = ListTile(
           // title - careful changing this, as the tiles are sorted based on this
           title: Text(
             DateFormat('dd-MM-yyyy HH:mm:ss').format(serve.timestamp),
@@ -168,46 +168,6 @@ class _LogState extends State<Log> {
                   ),
                 ),
               ),
-
-              // laddu packs served
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text('Laddu packs served: '),
-              ),
-              for (int i = 0; i < serve.packsPushpanjali.length; i++)
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    '    Seva ${serve.packsPushpanjali[i].keys.first}: ${serve.packsPushpanjali[i].values.first}',
-                    style: TextStyle(
-                      color: serve.packsPushpanjali[i].values.first == 0
-                          ? Colors.grey
-                          : Colors.black,
-                    ),
-                  ),
-                ),
-              for (int i = 0; i < serve.packsOthers.length; i++)
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    '    ${serve.packsOthers[i].keys.first}: ${serve.packsOthers[i].values.first}',
-                    style: TextStyle(
-                      color: serve.packsOthers[i].values.first == 0
-                          ? Colors.grey
-                          : Colors.black,
-                    ),
-                  ),
-                ),
-
-              // note
-              if (serve.note.isNotEmpty)
-                Align(
-                  alignment: Alignment.centerLeft,
-                  child: Container(
-                    color: Colors.yellow,
-                    child: Text('Note: ${serve.note}'),
-                  ),
-                ),
             ],
           ),
 
@@ -223,7 +183,61 @@ class _LogState extends State<Log> {
           //   // addEditDist(context,
           //   //     edit: true, serve: serve, session: widget.session);
           // }
-        ));
+        );
+
+        // heading for laddu packs served
+        (tile.subtitle as Column).children.add(Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Laddu packs served: '),
+            ));
+
+        // all pushpanjali tickets
+        for (int i = 0; i < serve.packsPushpanjali.length; i++) {
+          if (serve.packsPushpanjali[i].values.first != 0) {
+            (tile.subtitle as Column).children.add(Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '    Seva ${serve.packsPushpanjali[i].keys.first}: ${serve.packsPushpanjali[i].values.first}',
+                  ),
+                ));
+          }
+        }
+
+        // other seva tickets
+        for (int i = 0; i < serve.packsPushpanjali.length; i++) {
+          if (serve.packsPushpanjali[i].values.first != 0) {
+            (tile.subtitle as Column).children.add(Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '    Seva ${serve.packsPushpanjali[i].keys.first}: ${serve.packsPushpanjali[i].values.first}',
+                  ),
+                ));
+          }
+        }
+
+        // all misc
+        for (int i = 0; i < serve.packsMisc.length; i++) {
+          if (serve.packsMisc[i].values.first != 0) {
+            (tile.subtitle as Column).children.add(Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '    ${serve.packsMisc[i].keys.first}: ${serve.packsMisc[i].values.first}',
+                  ),
+                ));
+          }
+        }
+
+        // note
+        if (serve.note.isNotEmpty)
+          (tile.subtitle as Column).children.add(Align(
+                alignment: Alignment.centerLeft,
+                child: Container(
+                  color: Colors.yellow,
+                  child: Text('Note: ${serve.note}'),
+                ),
+              ));
+
+        _logItems.add(tile);
       }
 
       _logItems.sort((a, b) {
@@ -253,7 +267,7 @@ class _LogState extends State<Log> {
       total += element.values.first;
     });
 
-    serve.packsOthers.forEach((element) {
+    serve.packsMisc.forEach((element) {
       total += element.values.first;
     });
 

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -110,7 +110,7 @@ class _LogState extends State<Log> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      _calculateTotalLadduPacksServed(serve).toString(),
+                      serve.totalPacks().toString(),
                       style: TextStyle(
                         fontSize: 24.0, // Increase font size
                         fontWeight: FontWeight.bold, // Make text bold
@@ -259,24 +259,6 @@ class _LogState extends State<Log> {
     if (mounted) {
       setState(() {});
     }
-  }
-
-  int _calculateTotalLadduPacksServed(LadduServe serve) {
-    int total = 0;
-
-    serve.packsPushpanjali.forEach((element) {
-      total += element.values.first;
-    });
-
-    serve.packsOtherSeva.forEach((element) {
-      total += element.values.first;
-    });
-
-    serve.packsMisc.forEach((element) {
-      total += element.values.first;
-    });
-
-    return total;
   }
 
   Widget _getListView() {

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -85,105 +85,106 @@ class _LogState extends State<Log> {
       List<LadduServe> serves = await FB().readLadduServes(session);
       for (LadduServe serve in serves) {
         ListTile tile = ListTile(
-          // title - careful changing this, as the tiles are sorted based on this
-          title: Text(
-            DateFormat('dd-MM-yyyy HH:mm:ss').format(serve.timestamp),
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              fontSize: 18.0, // Adjust the font size as needed
-            ),
-          ),
-
-          // add or remove icon
-          leading: const Icon(Icons.remove),
-
-          // total count
-          trailing: Container(
-            padding: EdgeInsets.all(8.0),
-            decoration: BoxDecoration(
-              border: Border.all(color: Colors.black),
-              borderRadius: BorderRadius.circular(8.0),
-            ),
-            child: FittedBox(
-              fit: BoxFit.scaleDown,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    _calculateTotalLadduPacksServed(serve).toString(),
-                    style: TextStyle(
-                      fontSize: 24.0, // Increase font size
-                      fontWeight: FontWeight.bold, // Make text bold
-                    ),
-                  ),
-                  Text("Total"),
-                ],
+            // title - careful changing this, as the tiles are sorted based on this
+            title: Text(
+              DateFormat('dd-MM-yyyy HH:mm:ss').format(serve.timestamp),
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 18.0, // Adjust the font size as needed
               ),
             ),
-          ),
 
-          // all details
-          subtitle: Column(
-            children: [
-              // slot name
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Container(
-                  color: Colors.black, // Dark background color
-                  child: Text(
-                    serve.title,
-                    style: TextStyle(
-                      color: Colors.white, // Light text color
+            // add or remove icon
+            leading: const Icon(Icons.remove),
+
+            // total count
+            trailing: Container(
+              padding: EdgeInsets.all(8.0),
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.black),
+                borderRadius: BorderRadius.circular(8.0),
+              ),
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _calculateTotalLadduPacksServed(serve).toString(),
+                      style: TextStyle(
+                        fontSize: 24.0, // Increase font size
+                        fontWeight: FontWeight.bold, // Make text bold
+                      ),
+                    ),
+                    Text("Total"),
+                  ],
+                ),
+              ),
+            ),
+
+            // all details
+            subtitle: Column(
+              children: [
+                // slot name
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    color: Colors.black, // Dark background color
+                    child: Text(
+                      serve.title,
+                      style: TextStyle(
+                        color: Colors.white, // Light text color
+                      ),
                     ),
                   ),
                 ),
-              ),
 
-              // sevakarta
-              Align(
-                alignment: Alignment.centerLeft,
-                child: Text.rich(
-                  TextSpan(
-                    children: [
-                      TextSpan(
-                        text: 'Sevakarta: ',
-                        style: TextStyle(
-                          fontSize: 16.0, // Replace with your desired font size
-                          color:
-                              Colors.black, // Replace with your desired color
+                // sevakarta
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text.rich(
+                    TextSpan(
+                      children: [
+                        TextSpan(
+                          text: 'Sevakarta: ',
+                          style: TextStyle(
+                            fontSize:
+                                16.0, // Replace with your desired font size
+                            color:
+                                Colors.black, // Replace with your desired color
+                          ),
                         ),
-                      ),
-                      TextSpan(
-                        text: '${serve.user}',
-                        style: TextStyle(
-                          fontFamily:
-                              'YourFontFamily', // Replace with your font family
-                          fontSize: 16.0, // Replace with your desired font size
-                          color:
-                              Colors.black, // Replace with your desired color
-                          fontStyle: FontStyle.italic, // Make the text italic
+                        TextSpan(
+                          text: '${serve.user}',
+                          style: TextStyle(
+                            fontFamily:
+                                'YourFontFamily', // Replace with your font family
+                            fontSize:
+                                16.0, // Replace with your desired font size
+                            color:
+                                Colors.black, // Replace with your desired color
+                            fontStyle: FontStyle.italic, // Make the text italic
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
-          ),
+              ],
+            ),
 
-          // edit on tap
-          // onTap: () {
-          //   Navigator.push(
-          //     context,
-          //     MaterialPageRoute(
-          //         builder: (context) => Serve(
-          //               serve: serve,
-          //             )),
-          //   );
-          //   // addEditDist(context,
-          //   //     edit: true, serve: serve, session: widget.session);
-          // }
-        );
+            // edit on tap
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (context) => Serve(
+                          serve: serve,
+                        )),
+              );
+              // addEditDist(context,
+              //     edit: true, serve: serve, session: widget.session);
+            });
 
         // heading for laddu packs served
         (tile.subtitle as Column).children.add(Align(
@@ -264,6 +265,10 @@ class _LogState extends State<Log> {
     int total = 0;
 
     serve.packsPushpanjali.forEach((element) {
+      total += element.values.first;
+    });
+
+    serve.packsOtherSeva.forEach((element) {
       total += element.values.first;
     });
 

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -54,15 +54,24 @@ class _LogState extends State<Log> {
               children: [
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: Text('Sevakarta: ${stock.user}'),
+                  child: Text(
+                    'Sevakarta: ${stock.user}',
+                    style: TextStyle(color: Colors.green[900]),
+                  ),
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: Text('Laddu packs collected: ${stock.count}'),
+                  child: Text(
+                    'Laddu packs collected: ${stock.count}',
+                    style: TextStyle(color: Colors.green[900]),
+                  ),
                 ),
                 Align(
                   alignment: Alignment.centerLeft,
-                  child: Text('Collected from: ${stock.from}'),
+                  child: Text(
+                    'Collected from: ${stock.from}',
+                    style: TextStyle(color: Colors.green[900]),
+                  ),
                 ),
               ],
             ),

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -32,9 +32,13 @@ class _LogState extends State<Log> {
       List<LadduStock> stocks = await FB().readLadduStocks(session);
       for (LadduStock stock in stocks) {
         _logItems.add(ListTile(
+
+            // title
             title: Text(
                 DateFormat('dd-MM-yyyy HH:mm:ss').format(stock.timestamp),
                 style: TextStyle(fontWeight: FontWeight.bold)),
+
+            // leading icon
             leading: const Icon(Icons.add),
 
             // body

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -36,11 +36,18 @@ class _LogState extends State<Log> {
 
             // title
             title: Text(
-                DateFormat('dd-MM-yyyy HH:mm:ss').format(stock.timestamp),
-                style: TextStyle(fontWeight: FontWeight.bold)),
+              DateFormat('dd-MM-yyyy HH:mm:ss').format(stock.timestamp),
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: Colors.green[800],
+              ),
+            ),
 
             // leading icon
-            leading: const Icon(Icons.add),
+            leading: Icon(
+              Icons.add,
+              color: Colors.green[800],
+            ),
 
             // body
             subtitle: Column(
@@ -64,6 +71,8 @@ class _LogState extends State<Log> {
             trailing: Container(
               padding: EdgeInsets.all(8.0), // Add padding around the text
               decoration: BoxDecoration(
+                color:
+                    Colors.green[100], // Change background color to light green
                 border:
                     Border.all(color: Colors.black, width: 2.0), // Add a border
                 borderRadius:
@@ -102,7 +111,7 @@ class _LogState extends State<Log> {
             // add or remove icon
             leading: const Icon(Icons.remove),
 
-            // total count
+            // trailer : total count
             trailing: Container(
               padding: EdgeInsets.all(8.0),
               decoration: BoxDecoration(
@@ -115,7 +124,7 @@ class _LogState extends State<Log> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      CalculateTotalLadduPacks(serve).toString(),
+                      CalculateTotalLadduPacksServed(serve).toString(),
                       style: TextStyle(
                         fontSize: 24.0, // Increase font size
                         fontWeight: FontWeight.bold, // Make text bold
@@ -230,6 +239,12 @@ class _LogState extends State<Log> {
                 ));
           }
         }
+
+        // balance
+        (tile.subtitle as Column).children.add(Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Balance: ${serve.balance}'),
+            ));
 
         // note
         if (serve.note.isNotEmpty)

--- a/lib/laddu_seva/log.dart
+++ b/lib/laddu_seva/log.dart
@@ -3,6 +3,7 @@ import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
 import 'package:garuda/laddu_seva/laddu_calc.dart';
 import 'package:garuda/laddu_seva/serve.dart';
+import 'package:garuda/laddu_seva/utils.dart';
 import 'package:intl/intl.dart';
 import 'package:synchronized/synchronized.dart';
 
@@ -114,7 +115,7 @@ class _LogState extends State<Log> {
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     Text(
-                      serve.totalPacks().toString(),
+                      CalculateTotalLadduPacks(serve).toString(),
                       style: TextStyle(
                         fontSize: 24.0, // Increase font size
                         fontWeight: FontWeight.bold, // Make text bold

--- a/lib/laddu_seva/main.dart
+++ b/lib/laddu_seva/main.dart
@@ -16,6 +16,7 @@ class LadduMain extends StatefulWidget {
 class _LadduSevaState extends State<LadduMain> {
   DateTime? session;
   LadduReturn? lr;
+  DateTime lastRefresh = DateTime.now();
 
   @override
   initState() {
@@ -30,6 +31,11 @@ class _LadduSevaState extends State<LadduMain> {
   }
 
   Future<void> refresh() async {
+    if (DateTime.now().difference(lastRefresh).inSeconds < 2) {
+      return;
+    }
+    lastRefresh = DateTime.now();
+
     // refresh the main widget
     session = await FB().readLatestLadduSession();
     lr = await FB().readLadduReturnStatus(session!);

--- a/lib/laddu_seva/main.dart
+++ b/lib/laddu_seva/main.dart
@@ -64,26 +64,38 @@ class _LadduSevaState extends State<LadduMain> {
   Widget _createReturnTile(LadduReturn lr) {
     return ListTile(
         // title
-        title: Text(DateFormat('dd-MM-yyyy HH:mm:ss').format(lr.timestamp),
-            style: TextStyle(fontWeight: FontWeight.bold)),
+        title: Text(
+          DateFormat('dd-MM-yyyy HH:mm:ss').format(lr.timestamp),
+          style:
+              TextStyle(fontWeight: FontWeight.bold, color: Color(0xFF8A0303)),
+        ),
 
         // icon
-        leading: const Icon(Icons.undo),
+        leading: Icon(Icons.undo, color: Color(0xFF8A0303)),
 
         // body
         subtitle: Column(
           children: [
             Align(
               alignment: Alignment.centerLeft,
-              child: Text('Sevakarta: ${lr.user}'),
+              child: Text(
+                'Sevakarta: ${lr.user}',
+                style: TextStyle(color: Color(0xFF8A0303)),
+              ),
             ),
             Align(
               alignment: Alignment.centerLeft,
-              child: Text('Laddu packs returned: ${lr.count}'),
+              child: Text(
+                'Laddu packs returned: ${lr.count}',
+                style: TextStyle(color: Color(0xFF8A0303)),
+              ),
             ),
             Align(
               alignment: Alignment.centerLeft,
-              child: Text('Returned to: ${lr.to}'),
+              child: Text(
+                'Returned to: ${lr.to}',
+                style: TextStyle(color: Color(0xFF8A0303)),
+              ),
             ),
           ],
         ),
@@ -92,13 +104,17 @@ class _LadduSevaState extends State<LadduMain> {
         trailing: Container(
           padding: EdgeInsets.all(8.0), // Add padding around the text
           decoration: BoxDecoration(
-            border: Border.all(color: Colors.black, width: 2.0), // Add a border
+            color: Colors.red[50], // Change background color to red
+            border: Border.all(
+                color: Color(0xFF8A0303), width: 2.0), // Add a border
             borderRadius:
                 BorderRadius.circular(12.0), // Make the border circular
           ),
           child: Text(
             lr.count.toString(),
-            style: TextStyle(fontSize: 24.0), // Increase the font size
+            style: TextStyle(
+                fontSize: 24.0,
+                color: Color(0xFF8A0303)), // Increase the font size
           ),
         ),
 

--- a/lib/laddu_seva/main.dart
+++ b/lib/laddu_seva/main.dart
@@ -17,7 +17,7 @@ class LadduMain extends StatefulWidget {
 class _LadduSevaState extends State<LadduMain> {
   DateTime? session;
   LadduReturn? lr;
-  DateTime lastRefresh = DateTime.now();
+  DateTime? lastRefresh;
 
   @override
   initState() {
@@ -32,7 +32,8 @@ class _LadduSevaState extends State<LadduMain> {
   }
 
   Future<void> refresh() async {
-    if (DateTime.now().difference(lastRefresh).inSeconds < 2) {
+    if (lastRefresh != null &&
+        DateTime.now().difference(lastRefresh!).inSeconds < 2) {
       return;
     }
     lastRefresh = DateTime.now();
@@ -60,7 +61,7 @@ class _LadduSevaState extends State<LadduMain> {
     }
   }
 
-  Widget _getReturnTile(LadduReturn lr) {
+  Widget _createReturnTile(LadduReturn lr) {
     return ListTile(
         // title
         title: Text(DateFormat('dd-MM-yyyy HH:mm:ss').format(lr.timestamp),
@@ -189,7 +190,7 @@ class _LadduSevaState extends State<LadduMain> {
                     style: TextStyle(color: Colors.red, fontSize: 20.0),
                   ),
                   Divider(),
-                  _getReturnTile(lr!),
+                  _createReturnTile(lr!),
                   Divider(),
                 ],
               ),

--- a/lib/laddu_seva/main.dart
+++ b/lib/laddu_seva/main.dart
@@ -134,10 +134,11 @@ class _LadduSevaState extends State<LadduMain> {
                     "Click '+ Stock' to start",
                     style: TextStyle(color: Colors.red, fontSize: 20.0),
                   ),
+                  Divider()
                 ],
               ),
 
-            if (lr == null || lr!.count == -1) Log(key: LogKey),
+            Log(key: LogKey),
           ],
         ),
       ),

--- a/lib/laddu_seva/main.dart
+++ b/lib/laddu_seva/main.dart
@@ -7,6 +7,7 @@ import 'package:garuda/laddu_seva/laddu_calc.dart';
 import 'package:garuda/laddu_seva/log.dart';
 import 'package:garuda/laddu_seva/serve.dart';
 import 'package:garuda/laddu_seva/summary.dart';
+import 'package:intl/intl.dart';
 
 class LadduMain extends StatefulWidget {
   @override
@@ -57,6 +58,53 @@ class _LadduSevaState extends State<LadduMain> {
         await LogKey.currentState!.refresh();
       }
     }
+  }
+
+  Widget _getReturnTile(LadduReturn lr) {
+    return ListTile(
+        // title
+        title: Text(DateFormat('dd-MM-yyyy HH:mm:ss').format(lr.timestamp),
+            style: TextStyle(fontWeight: FontWeight.bold)),
+
+        // icon
+        leading: const Icon(Icons.undo),
+
+        // body
+        subtitle: Column(
+          children: [
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Sevakarta: ${lr.user}'),
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Laddu packs returned: ${lr.count}'),
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Returned to: ${lr.to}'),
+            ),
+          ],
+        ),
+
+        // the count
+        trailing: Container(
+          padding: EdgeInsets.all(8.0), // Add padding around the text
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.black, width: 2.0), // Add a border
+            borderRadius:
+                BorderRadius.circular(12.0), // Make the border circular
+          ),
+          child: Text(
+            lr.count.toString(),
+            style: TextStyle(fontSize: 24.0), // Increase the font size
+          ),
+        ),
+
+        // on tap
+        onTap: () async {
+          returnStock(context, lr: lr);
+        });
   }
 
   @override
@@ -132,15 +180,17 @@ class _LadduSevaState extends State<LadduMain> {
 
             Divider(),
 
-            // if session is closed, display a message
+            // if session is closed, display a message and the return tile
             if (lr != null && lr!.count >= 0)
               Column(
                 children: [
                   Text(
-                    "Click '+ Stock' to start",
+                    "Click '+ Stock' to start new session",
                     style: TextStyle(color: Colors.red, fontSize: 20.0),
                   ),
-                  Divider()
+                  Divider(),
+                  _getReturnTile(lr!),
+                  Divider(),
                 ],
               ),
 

--- a/lib/laddu_seva/serve.dart
+++ b/lib/laddu_seva/serve.dart
@@ -45,14 +45,19 @@ class _ServeState extends State<Serve> {
       // assuming that all sequences are correct
 
       // controllers for pushpanjali
+      for (int i = 0; i < widget.serve!.packsOtherSeva.length; i++) {
+        int divider = Const().otherSevaTickets[i]['ladduPacks']!;
+        int value = widget.serve!.packsOtherSeva[i].values.first ~/ divider;
+        _controllersOtherSeva[i].text = value.toString();
+      }
+
+      // controllers for other sevas
       for (int i = 0; i < widget.serve!.packsPushpanjali.length; i++) {
         int divider = Const().pushpanjaliTickets[i]['ladduPacks']!;
         int value = widget.serve!.packsPushpanjali[i].values.first ~/ divider;
         _controllersPushpanjali[i].text =
             value.toString(); // assuming that there is only one key-value pair
       }
-
-      // TODO: controllers for other sevas
 
       // controllers for misc
       for (int i = 0; i < widget.serve!.packsMisc.length; i++) {

--- a/lib/laddu_seva/serve.dart
+++ b/lib/laddu_seva/serve.dart
@@ -20,19 +20,19 @@ class _ServeState extends State<Serve> {
   TextEditingController _controllerTitle = TextEditingController();
 
   int _totalLadduPacks = 0;
-  List<String> _otherSevas = ["Others", "Missing"];
+  List<String> _otherSevas = ["Others"];
   bool _isLoading = false;
 
   @override
   void initState() {
     super.initState();
 
-    List<int?> ticketAmounts =
-        Const().ticketAmounts.map((e) => e['amount']).toList();
+    List<int?> pushpanjaliTickets =
+        Const().pushpanjaliTickets.map((e) => e['amount']).toList();
 
     // default populate the controllers
-    _controllersPushpanjali =
-        List.generate(ticketAmounts.length, (index) => TextEditingController());
+    _controllersPushpanjali = List.generate(
+        pushpanjaliTickets.length, (index) => TextEditingController());
     _controllersOthers =
         List.generate(_otherSevas.length, (index) => TextEditingController());
 
@@ -42,7 +42,7 @@ class _ServeState extends State<Serve> {
 
       // controllers for pushpanjali
       for (int i = 0; i < widget.serve!.packsPushpanjali.length; i++) {
-        int divider = Const().ticketAmounts[i]['ladduPacks']!;
+        int divider = Const().pushpanjaliTickets[i]['ladduPacks']!;
         int value = widget.serve!.packsPushpanjali[i].values.first ~/ divider;
         _controllersPushpanjali[i].text =
             value.toString(); // assuming that there is only one key-value pair
@@ -81,7 +81,7 @@ class _ServeState extends State<Serve> {
     _totalLadduPacks = 0;
     for (int i = 0; i < _controllersPushpanjali.length; i++) {
       if (_controllersPushpanjali[i].text.isNotEmpty) {
-        int multiplier = Const().ticketAmounts[i]['ladduPacks']!;
+        int multiplier = Const().pushpanjaliTickets[i]['ladduPacks']!;
         _totalLadduPacks +=
             (int.tryParse(_controllersPushpanjali[i].text)! * multiplier);
       }
@@ -92,8 +92,8 @@ class _ServeState extends State<Serve> {
   }
 
   Widget _createTable() {
-    List<int?> ticketAmounts =
-        Const().ticketAmounts.map((e) => e['amount']).toList();
+    List<int?> pushpanjaliTickets =
+        Const().pushpanjaliTickets.map((e) => e['amount']).toList();
 
     return Table(
       columnWidths: {
@@ -160,7 +160,7 @@ class _ServeState extends State<Serve> {
         ),
 
         // Table rows for pushpanjali
-        for (int i = 0; i < Const().ticketAmounts.length; i++)
+        for (int i = 0; i < Const().pushpanjaliTickets.length; i++)
           TableRow(
             children: [
               // seva cell
@@ -171,7 +171,7 @@ class _ServeState extends State<Serve> {
                   padding: const EdgeInsets.all(8.0),
                   child: Align(
                     alignment: Alignment.centerLeft,
-                    child: Text('Seva ${ticketAmounts[i]}'),
+                    child: Text('Seva ${pushpanjaliTickets[i]}'),
                   ),
                 ),
               ),
@@ -212,7 +212,7 @@ class _ServeState extends State<Serve> {
                     child: _controllersPushpanjali[i].text.isEmpty
                         ? Text("0")
                         : Text((int.parse(_controllersPushpanjali[i].text) *
-                                Const().ticketAmounts[i]['ladduPacks']!)
+                                Const().pushpanjaliTickets[i]['ladduPacks']!)
                             .toString()),
                   ),
                 ),
@@ -350,21 +350,21 @@ class _ServeState extends State<Serve> {
                       List<Map<String, int>> packsPushpanjali = [];
                       List<Map<String, int>> packsOthers = [];
 
-                      List<int?> ticketAmounts = Const()
-                          .ticketAmounts
+                      List<int?> pushpanjaliTickets = Const()
+                          .pushpanjaliTickets
                           .map((e) => e['amount'])
                           .toList();
 
                       for (int i = 0; i < _controllersPushpanjali.length; i++) {
                         if (_controllersPushpanjali[i].text.isEmpty) {
                           packsPushpanjali
-                              .add({ticketAmounts[i]!.toString(): 0});
+                              .add({pushpanjaliTickets[i]!.toString(): 0});
                           continue;
                         }
                         packsPushpanjali.add({
-                          ticketAmounts[i]!.toString():
+                          pushpanjaliTickets[i]!.toString():
                               int.tryParse(_controllersPushpanjali[i].text)! *
-                                  Const().ticketAmounts[i]['ladduPacks']!
+                                  Const().pushpanjaliTickets[i]['ladduPacks']!
                         });
                       }
                       for (int i = 0; i < _controllersOthers.length; i++) {

--- a/lib/laddu_seva/serve.dart
+++ b/lib/laddu_seva/serve.dart
@@ -210,6 +210,8 @@ class _ServeState extends State<Serve> {
                   child: Center(
                     child: TextField(
                       controller: _controllersPushpanjali[i],
+                      keyboardType:
+                          TextInputType.number, // Set keyboard to numeric
                       onChanged: (value) {
                         setState(() {
                           _calculateTotalLadduPacks();
@@ -262,7 +264,7 @@ class _ServeState extends State<Serve> {
                 ),
               ),
 
-              // number of tickets
+              // number of tickets for other Seva
               TableCell(
                 verticalAlignment:
                     TableCellVerticalAlignment.middle, // Center vertically
@@ -271,6 +273,7 @@ class _ServeState extends State<Serve> {
                   child: Center(
                     child: TextField(
                       controller: _controllersOtherSeva[i],
+                      keyboardType: TextInputType.number,
                       onChanged: (value) {
                         setState(() {
                           _calculateTotalLadduPacks();
@@ -335,7 +338,7 @@ class _ServeState extends State<Serve> {
                 ),
               ),
 
-              // packs cell
+              // packs cell for misc
               TableCell(
                 verticalAlignment:
                     TableCellVerticalAlignment.middle, // Center vertically
@@ -355,6 +358,7 @@ class _ServeState extends State<Serve> {
                             vertical: 8.0, horizontal: 8.0),
                       ),
                       controller: _controllerMisc[_misc.indexOf(seva)],
+                      keyboardType: TextInputType.number,
                     ),
                   ),
                 ),

--- a/lib/laddu_seva/serve.dart
+++ b/lib/laddu_seva/serve.dart
@@ -443,6 +443,32 @@ class _ServeState extends State<Serve> {
     Navigator.pop(context);
   }
 
+  Future<bool?> _createConfirmDialog() async {
+    return await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text('Confirmation'),
+          content: Text('Are you sure you want to delete?'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(false);
+              },
+              child: Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop(true);
+              },
+              child: Text('Confirm'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -505,6 +531,38 @@ class _ServeState extends State<Serve> {
                   ? CircularProgressIndicator()
                   : Text(widget.serve != null ? 'Update' : 'Serve'),
             ),
+
+            // delete button
+            if (widget.serve != null)
+              ElevatedButton(
+                onPressed: _isLoading
+                    ? null
+                    : () async {
+                        bool? confirm = await _createConfirmDialog();
+
+                        if (confirm == true) {
+                          setState(() {
+                            _isLoading = true;
+                          });
+
+                          DateTime session =
+                              await FB().readLatestLadduSession();
+                          await FB().deleteLadduServe(session, widget.serve!);
+
+                          setState(() {
+                            _isLoading = false;
+                          });
+
+                          Navigator.pop(context);
+                        }
+                      },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor:
+                      Colors.red, // Set the background color to red
+                ),
+                child:
+                    _isLoading ? CircularProgressIndicator() : Text('Delete'),
+              ),
           ],
         ),
       ),

--- a/lib/laddu_seva/serve.dart
+++ b/lib/laddu_seva/serve.dart
@@ -429,6 +429,7 @@ class _ServeState extends State<Serve> {
                       });
 
                       List<Map<String, int>> packsPushpanjali = [];
+                      List<Map<String, int>> packsOtherSeva = [];
                       List<Map<String, int>> packsMisc = [];
 
                       List<int?> pushpanjaliTickets = Const()
@@ -436,6 +437,7 @@ class _ServeState extends State<Serve> {
                           .map((e) => e['amount'])
                           .toList();
 
+                      // pushpanjali
                       for (int i = 0; i < _controllersPushpanjali.length; i++) {
                         if (_controllersPushpanjali[i].text.isEmpty) {
                           packsPushpanjali
@@ -448,6 +450,25 @@ class _ServeState extends State<Serve> {
                                   Const().pushpanjaliTickets[i]['ladduPacks']!
                         });
                       }
+
+                      // other sevas
+                      for (int i = 0; i < _controllersOtherSeva.length; i++) {
+                        // no entries
+                        if (_controllersOtherSeva[i].text.isEmpty) {
+                          packsOtherSeva
+                              .add({Const().otherSevaTickets[i]['name']: 0});
+                          continue;
+                        }
+
+                        // add entries
+                        int mul = Const().otherSevaTickets[i]['ladduPacks']!;
+                        packsOtherSeva.add({
+                          Const().otherSevaTickets[i]['name']:
+                              int.tryParse(_controllersOtherSeva[i].text)! * mul
+                        });
+                      }
+
+                      // misc
                       for (int i = 0; i < _controllerMisc.length; i++) {
                         packsMisc.add({
                           _misc[i]: int.tryParse(_controllerMisc[i].text) ?? 0
@@ -459,6 +480,7 @@ class _ServeState extends State<Serve> {
                         timestamp: now,
                         user: await Const().getUserName(),
                         packsPushpanjali: packsPushpanjali,
+                        packsOtherSeva: packsOtherSeva,
                         packsMisc: packsMisc,
                         note: _controllerNote.text,
                         title: _controllerTitle.text,

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -65,7 +65,7 @@ class _SummaryState extends State<Summary> {
 
       total_served = 0;
       for (var serve in serves) {
-        total_served += _calculateTotalLadduPacksServed(serve);
+        total_served += serve.totalPacks();
 
         // calculate pie chart values for Pushpanjali Seva
         serve.packsPushpanjali.forEach((element) {
@@ -177,24 +177,6 @@ class _SummaryState extends State<Summary> {
   Future<void> refresh() async {
     await _futureInit();
     setState(() {});
-  }
-
-  int _calculateTotalLadduPacksServed(LadduServe serve) {
-    int total = 0;
-
-    serve.packsPushpanjali.forEach((element) {
-      total += element.values.first;
-    });
-
-    serve.packsOtherSeva.forEach((element) {
-      total += element.values.first;
-    });
-
-    serve.packsMisc.forEach((element) {
-      total += element.values.first;
-    });
-
-    return total;
   }
 
   void restock(int procured) {

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -71,12 +71,14 @@ class _SummaryState extends State<Summary> {
         serve.packsPushpanjali.forEach((element) {
           String purpose = "Seva ${element.keys.first}";
           int count = element.values.first;
-          if (labels.contains(purpose)) {
-            int index = labels.indexOf(purpose);
-            values[index] += count;
-          } else {
-            labels.add(purpose);
-            values.add(count);
+          if (count > 0) {
+            if (labels.contains(purpose)) {
+              int index = labels.indexOf(purpose);
+              values[index] += count;
+            } else {
+              labels.add(purpose);
+              values.add(count);
+            }
           }
         });
 
@@ -84,12 +86,14 @@ class _SummaryState extends State<Summary> {
         serve.packsOtherSeva.forEach((element) {
           String purpose = "${element.keys.first}";
           int count = element.values.first;
-          if (labels.contains(purpose)) {
-            int index = labels.indexOf(purpose);
-            values[index] += count;
-          } else {
-            labels.add(purpose);
-            values.add(count);
+          if (count > 0) {
+            if (labels.contains(purpose)) {
+              int index = labels.indexOf(purpose);
+              values[index] += count;
+            } else {
+              labels.add(purpose);
+              values.add(count);
+            }
           }
         });
 
@@ -97,12 +101,14 @@ class _SummaryState extends State<Summary> {
         serve.packsMisc.forEach((element) {
           String purpose = element.keys.first;
           int count = element.values.first;
-          if (labels.contains(purpose)) {
-            int index = labels.indexOf(purpose);
-            values[index] += count;
-          } else {
-            labels.add(purpose);
-            values.add(count);
+          if (count > 0) {
+            if (labels.contains(purpose)) {
+              int index = labels.indexOf(purpose);
+              values[index] += count;
+            } else {
+              labels.add(purpose);
+              values.add(count);
+            }
           }
         });
       }

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -81,7 +81,7 @@ class _SummaryState extends State<Summary> {
         });
 
         // calculate pie chart values for Others
-        serve.packsOthers.forEach((element) {
+        serve.packsMisc.forEach((element) {
           String purpose = element.keys.first;
           int count = element.values.first;
           if (labels.contains(purpose)) {
@@ -168,7 +168,7 @@ class _SummaryState extends State<Summary> {
       total += element.values.first;
     });
 
-    serve.packsOthers.forEach((element) {
+    serve.packsMisc.forEach((element) {
       total += element.values.first;
     });
 

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -38,6 +38,11 @@ class _SummaryState extends State<Summary> {
       List<LadduStock> stocks = await FB().readLadduStocks(session);
       List<LadduServe> serves = await FB().readLadduServes(session);
 
+      // set laddu return status
+      FB().readLadduReturnStatus(session).then((value) {
+        lr = value;
+      });
+
       // formulate session title for summary widget
       sessionTitle = await CalculateSessionTitle(session);
 
@@ -190,12 +195,21 @@ class _SummaryState extends State<Summary> {
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
         SizedBox(
-          height: 100, // Set the desired height
-          width: 100, // Set the desired width
-          child: PieChart(
-            PieChartData(
-              sections: pieSections,
-            ),
+          child: Column(
+            children: [
+              SizedBox(
+                height: 100, // Set the desired height for the PieChart
+                width: 100, // Set the desired width for the PieChart
+                child: PieChart(
+                  PieChartData(
+                    sections: pieSections,
+                  ),
+                ),
+              ),
+              Text(
+                'Laddu packs served', // Replace with your desired text
+              ),
+            ],
           ),
         ),
         SizedBox(width: 40), // Increased space between the chart and the legend

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -67,7 +67,7 @@ class _SummaryState extends State<Summary> {
       for (var serve in serves) {
         total_served += _calculateTotalLadduPacksServed(serve);
 
-        // calculate pie chart values for Seva
+        // calculate pie chart values for Pushpanjali Seva
         serve.packsPushpanjali.forEach((element) {
           String purpose = "Seva ${element.keys.first}";
           int count = element.values.first;
@@ -80,7 +80,20 @@ class _SummaryState extends State<Summary> {
           }
         });
 
-        // calculate pie chart values for Others
+        // calculate pie chart values for other Seva
+        serve.packsOtherSeva.forEach((element) {
+          String purpose = "${element.keys.first}";
+          int count = element.values.first;
+          if (labels.contains(purpose)) {
+            int index = labels.indexOf(purpose);
+            values[index] += count;
+          } else {
+            labels.add(purpose);
+            values.add(count);
+          }
+        });
+
+        // calculate pie chart values for misc
         serve.packsMisc.forEach((element) {
           String purpose = element.keys.first;
           int count = element.values.first;
@@ -94,6 +107,10 @@ class _SummaryState extends State<Summary> {
         });
       }
 
+      List<String> sevaNames = Const().otherSevaTickets.map((e) {
+        String name = e['name'];
+        return name;
+      }).toList();
       // add the pie sections and legends
       for (int i = 0; i < labels.length; i++) {
         Color pieColor = Colors.grey;
@@ -103,11 +120,12 @@ class _SummaryState extends State<Summary> {
           pieColor = Const().ticketColors[amount]!;
           textColor =
               amount == "500" ? Theme.of(context).primaryColor : Colors.white;
+        } else if (sevaNames.contains(labels[i])) {
+          int index = sevaNames.indexOf(labels[i]);
+          pieColor = Const().otherSevaTickets[index]['color'];
         } else {
-          if (labels[i] == "Others") {
+          if (labels[i] == "Miscellaneous") {
             pieColor = Colors.grey;
-          } else if (labels[i] == "Missing") {
-            pieColor = Colors.redAccent;
           } else {
             pieColor = Const().getRandomDarkColor();
           }
@@ -165,6 +183,10 @@ class _SummaryState extends State<Summary> {
     int total = 0;
 
     serve.packsPushpanjali.forEach((element) {
+      total += element.values.first;
+    });
+
+    serve.packsOtherSeva.forEach((element) {
       total += element.values.first;
     });
 

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:garuda/const.dart';
 import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
+import 'package:garuda/laddu_seva/utils.dart';
 import 'package:intl/intl.dart';
 import 'package:synchronized/synchronized.dart';
 
@@ -37,19 +38,18 @@ class _SummaryState extends State<Summary> {
       List<LadduStock> stocks = await FB().readLadduStocks(session);
       List<LadduServe> serves = await FB().readLadduServes(session);
 
-      sessionTitle = DateFormat("EEE, MMM dd").format(session);
-
       // formulate session title for summary widget
-      DateTime now = DateTime.now();
-      if (session.day != now.day) {
-        sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
-      }
+      sessionTitle = DateFormat("EEE, MMM dd").format(session);
       lr = await FB().readLadduReturnStatus(session);
       if (lr!.count >= 0) {
-        String endSession =
-            "${lr!.timestamp.day}/${lr!.timestamp.month}/${lr!.timestamp.year}";
+        String endSession = DateFormat("EEE, MMM dd").format(lr!.timestamp);
         if (sessionTitle != endSession) {
           sessionTitle += " - $endSession";
+        }
+      } else {
+        DateTime now = DateTime.now();
+        if (session.day != now.day) {
+          sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
         }
       }
 
@@ -65,7 +65,7 @@ class _SummaryState extends State<Summary> {
 
       total_served = 0;
       for (var serve in serves) {
-        total_served += serve.totalPacks();
+        total_served += CalculateTotalLadduPacks(serve);
 
         // calculate pie chart values for Pushpanjali Seva
         serve.packsPushpanjali.forEach((element) {

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -350,6 +350,20 @@ class _SummaryState extends State<Summary> {
                     child: Text("Total laddu packs returned = ${lr!.count}"),
                   ),
                 ),
+
+                // calculate missing if any
+                if (total_procured != total_served + lr!.count) ...[
+                  Padding(
+                    padding: const EdgeInsets.only(left: 16.0),
+                    child: Align(
+                      alignment: Alignment.centerLeft,
+                      child: Text(
+                        "Total laddu packs missing = ${total_procured - total_served - lr!.count}",
+                        style: TextStyle(color: Colors.red),
+                      ),
+                    ),
+                  ),
+                ],
               ],
 
               // padding before pie chart

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -39,19 +39,7 @@ class _SummaryState extends State<Summary> {
       List<LadduServe> serves = await FB().readLadduServes(session);
 
       // formulate session title for summary widget
-      sessionTitle = DateFormat("EEE, MMM dd").format(session);
-      lr = await FB().readLadduReturnStatus(session);
-      if (lr!.count >= 0) {
-        String endSession = DateFormat("EEE, MMM dd").format(lr!.timestamp);
-        if (sessionTitle != endSession) {
-          sessionTitle += " - $endSession";
-        }
-      } else {
-        DateTime now = DateTime.now();
-        if (session.day != now.day) {
-          sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
-        }
-      }
+      sessionTitle = await CalculateSessionTitle(session);
 
       total_procured = 0;
       for (var stock in stocks) {

--- a/lib/laddu_seva/summary.dart
+++ b/lib/laddu_seva/summary.dart
@@ -53,7 +53,7 @@ class _SummaryState extends State<Summary> {
 
       total_served = 0;
       for (var serve in serves) {
-        total_served += CalculateTotalLadduPacks(serve);
+        total_served += CalculateTotalLadduPacksServed(serve);
 
         // calculate pie chart values for Pushpanjali Seva
         serve.packsPushpanjali.forEach((element) {

--- a/lib/laddu_seva/utils.dart
+++ b/lib/laddu_seva/utils.dart
@@ -1,4 +1,6 @@
+import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
+import 'package:intl/intl.dart';
 
 int CalculateTotalLadduPacks(LadduServe serve) {
   int total = 0;
@@ -21,4 +23,22 @@ int CalculateTotalLadduPacks(LadduServe serve) {
   });
 
   return total;
+}
+
+Future<String> CalculateSessionTitle(DateTime session) async {
+  String sessionTitle = DateFormat("EEE, MMM dd").format(session);
+  LadduReturn lr = await FB().readLadduReturnStatus(session);
+  if (lr.count >= 0) {
+    String endSession = DateFormat("EEE, MMM dd").format(lr.timestamp);
+    if (sessionTitle != endSession) {
+      sessionTitle += " - $endSession";
+    }
+  } else {
+    DateTime now = DateTime.now();
+    if (session.day != now.day) {
+      sessionTitle += DateFormat(" - EEE, MMM dd").format(now);
+    }
+  }
+
+  return sessionTitle;
 }

--- a/lib/laddu_seva/utils.dart
+++ b/lib/laddu_seva/utils.dart
@@ -2,7 +2,7 @@ import 'package:garuda/fb.dart';
 import 'package:garuda/laddu_seva/datatypes.dart';
 import 'package:intl/intl.dart';
 
-int CalculateTotalLadduPacks(LadduServe serve) {
+int CalculateTotalLadduPacksServed(LadduServe serve) {
   int total = 0;
   serve.packsPushpanjali.forEach((element) {
     element.forEach((key, value) {

--- a/lib/laddu_seva/utils.dart
+++ b/lib/laddu_seva/utils.dart
@@ -1,0 +1,24 @@
+import 'package:garuda/laddu_seva/datatypes.dart';
+
+int CalculateTotalLadduPacks(LadduServe serve) {
+  int total = 0;
+  serve.packsPushpanjali.forEach((element) {
+    element.forEach((key, value) {
+      total += value;
+    });
+  });
+
+  serve.packsOtherSeva.forEach((element) {
+    element.forEach((key, value) {
+      total += value;
+    });
+  });
+
+  serve.packsMisc.forEach((element) {
+    element.forEach((key, value) {
+      total += value;
+    });
+  });
+
+  return total;
+}

--- a/lib/pushpanjali/dashboard.dart
+++ b/lib/pushpanjali/dashboard.dart
@@ -76,9 +76,9 @@ class _DashboardState extends State<Dashboard> {
       amountTableTicketRow = [];
       Map<String, List<SevaTicket>> tickets =
           await FB().readSevaTicketsByDate(selectedDate);
-      List<int?> ticketAmounts =
-          Const().ticketAmounts.map((e) => e['amount']).toList();
-      for (var amount in ticketAmounts) {
+      List<int?> pushpanjaliTickets =
+          Const().pushpanjaliTickets.map((e) => e['amount']).toList();
+      for (var amount in pushpanjaliTickets) {
         List<int> row = _getRowData(tickets, amount!);
         bool rowReplaced = false;
         for (int i = 0; i < amountTableTicketRow.length; i++) {

--- a/lib/pushpanjali/summary.dart
+++ b/lib/pushpanjali/summary.dart
@@ -41,9 +41,9 @@ class _SummaryState extends State<Summary> {
     int totalCashAmount = 0;
     int totalCardAmount = 0;
 
-    List<int?> ticketAmounts =
-        Const().ticketAmounts.map((e) => e['amount']).toList();
-    for (int? amount in ticketAmounts) {
+    List<int?> pushpanjaliTickets =
+        Const().pushpanjaliTickets.map((e) => e['amount']).toList();
+    for (int? amount in pushpanjaliTickets) {
       List<SevaTicket> listFiltered =
           _listEntries!.where((e) => e.amount == amount).toList();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.1.1+14
+version: 2.2.0+15
 
 environment:
   sdk: '>=3.4.3 <4.0.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 GitPython
-PyGithub


### PR DESCRIPTION
- release 2.2.0
- fix return
- laddu return count in summary
- serve keyboard is now numeric
- slot balance is shown in serve tile
- title in seva history made uniform with summary
- delete serve
- all fields are made mandatory in a dialog
- return is editable
- missing laddu packs
- pie display only served tickets
- prevent multiple refresh
- edit serve
- Related to #issue_number
- new serve types added
- log serve
- other seva fb entry
- rename ticketAmounts